### PR TITLE
Add notes about dependency on ruby to README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/tasks.xml
 .idea/workspace.xml
 target
+.ruby-*

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ The only interface to Chaos Loris today is via a REST-ful interface.  This inter
 ### Java, Maven
 The application is written in Java 8 and packaged as a self executable JAR file. This enables it to run anywhere that Java is available.
 
+### Ruby, bundler
+In order to build the project you'll need to install Ruby and `bundler` gem. Chaos-loris uses them to render docs on a build stage. Run `gem install bundler` to get `bundler` gem.
+
 ## Configuration
 Since the application is designed to work in a cloud-native environment, all configuration is done with environment variables.
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,3 +5,8 @@ applications:
   instances: 1
   path: target/chaos-loris.jar
   buildpack: https://github.com/cloudfoundry/java-buildpack.git
+  env:
+    LORIS_CLOUDFOUNDRY_HOST: REPLACE_ME
+    LORIS_CLOUDFOUNDRY_PASSWORD: REPLACE_ME
+    LORIS_CLOUDFOUNDRY_SKIPSSLVALIDATION: false
+    LORIS_CLOUDFOUNDRY_USERNAME: REPLACE_ME


### PR DESCRIPTION
Hey, @nebhale.

I'll needed to install ruby and bundler gem in order to run `mvn package` without errors. When I run `./mvnw clean package` it gave me the following error:

```
[INFO]
[INFO] --- exec-maven-plugin:1.5.0:exec (bundle-install) @ chaos-loris ---
[ERROR] Command execution failed.
java.io.IOException: Cannot run program "bundle" (in directory "/Users/allomov/work/altoros/vmware/chaos-tools/chaos-loris/slate"): error=2, No such file or directory
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
	at java.lang.Runtime.exec(Runtime.java:620)
	at org.apache.commons.exec.launcher.Java13CommandLauncher.exec(Java13CommandLauncher.java:61)
	at org.apache.commons.exec.DefaultExecutor.launch(DefaultExecutor.java:279)
	at org.apache.commons.exec.DefaultExecutor.executeInternal(DefaultExecutor.java:336)
	at org.apache.commons.exec.DefaultExecutor.execute(DefaultExecutor.java:166)
	at org.codehaus.mojo.exec.ExecMojo.executeCommandLine(ExecMojo.java:764)
	at org.codehaus.mojo.exec.ExecMojo.executeCommandLine(ExecMojo.java:711)
	at org.codehaus.mojo.exec.ExecMojo.execute(ExecMojo.java:289)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:207)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:863)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:199)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.maven.wrapper.BootstrapMainStarter.start(BootstrapMainStarter.java:39)
	at org.apache.maven.wrapper.WrapperExecutor.execute(WrapperExecutor.java:122)
	at org.apache.maven.wrapper.MavenWrapperMain.main(MavenWrapperMain.java:50)
Caused by: java.io.IOException: error=2, No such file or directory
	at java.lang.UNIXProcess.forkAndExec(Native Method)
	at java.lang.UNIXProcess.<init>(UNIXProcess.java:247)
	at java.lang.ProcessImpl.start(ProcessImpl.java:134)
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
	... 37 more
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 16.159 s
[INFO] Finished at: 2017-01-19T15:11:14-08:00
[INFO] Final Memory: 51M/488M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.codehaus.mojo:exec-maven-plugin:1.5.0:exec (bundle-install) on project chaos-loris: Command execution failed. Cannot run program "bundle" (in directory "/Users/allomov/work/altoros/vmware/chaos-tools/chaos-loris/slate"): error=2, No such file or directory -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

I needed to install ruby and bundler gem in order to build a jar. 

Also I added section for env variables to manifest.yml file to make it easier to see how to deploy the app to CF without errors.