### PR TITLE
Remove chaos foreign key from event table

### DIFF
--- a/src/main/resources/db/migration/V4__event.sql
+++ b/src/main/resources/db/migration/V4__event.sql
@@ -18,8 +18,7 @@ CREATE TABLE event (
   executed_at          DATETIME NOT NULL,
   total_instance_count INTEGER  NOT NULL,
 
-  PRIMARY KEY (id),
-  FOREIGN KEY (chaos_id) REFERENCES chaos (id)
+  PRIMARY KEY (id)
 );
 
 CREATE TABLE event_terminated_instances (


### PR DESCRIPTION
Hey, @nebhale 

I tried to run following command `curl -k -X DELETE "https://$CHAOS_LORIS_HOST/chaoses/1" -i -H 'Accept: application/hal+json'` and got thee following error in app logs:
```
2017-02-02T23:40:57.86-0800 [APP/1]      OUT [CHAOS LORIS] WARN  SQL Error: 1451, SQLState: 23000
2017-02-02T23:40:57.86-0800 [APP/1]      OUT [CHAOS LORIS] ERROR Cannot delete or update a parent row: a foreign key constraint fails (`cf_8454cd25_f55c_4422_9e7a_9b62f6fc7005`.`event`, CONSTRAINT `event_ibfk_1` FOREIGN KEY (`chaos_id`) REFERENCES `chaos` (`id`))
2017-02-02T23:40:57.86-0800 [APP/1]      OUT Query is: delete from chaos where id=?
```
The request returned 400 status. 

To solve this issue I needed to run following command in chaos loris database
```
ALTER TABLE cf_8454cd25_f55c_4422_9e7a_9b62f6fc7005.event DROP FOREIGN KEY event_ibfk_1;
```

This PR removes adding foreign key in migration for `event` table. This should solve the issue for others.

Thank you,
Alex L.