### PR TITLE
Fix app instances termination method call.

### DIFF
--- a/src/main/java/io/pivotal/strepsirrhini/chaosloris/destroyer/StandardDestroyer.java
+++ b/src/main/java/io/pivotal/strepsirrhini/chaosloris/destroyer/StandardDestroyer.java
@@ -75,7 +75,7 @@ final class StandardDestroyer implements Destroyer {
             .then(instanceCount -> Flux.range(0, instanceCount)
                 .flatMap(index -> Mono.just(fateEngine.getFate(chaos))
                     .filter(fate -> THUMBS_DOWN == fate)
-                    .then(terminate(chaos.getApplication(), index, platform)))
+                    .then(fate -> terminate(chaos.getApplication(), index, platform)))
                 .collectList()
                 .map(terminatedInstances -> new Event(chaos, Instant.now(), terminatedInstances, instanceCount)))
             .then(event -> Mono.just(eventRepository.save(event)))


### PR DESCRIPTION
Currently, all app instances are killed by chaos-loris, no matter what probability you specify.

This happens because reactor expect you to pass [one function](https://projectreactor.io/docs/core/release/api/reactor/core/publisher/Mono.html#then-java.util.function.Function-) function that accepts one argument and produces a result. Otherwise it will call any lambda you pass there considering it to be a Supplier.

Calling `terminate` method without wrapping it in lambda causes this method to be call time flatMap calls callback.